### PR TITLE
Add a join() method to the multitimer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ timer.start()
 time.sleep(5)
 timer.stop()
 
+# and potentially waited for (in case an iteration was in progress)
+timer.join()
+
 
 # If a mutable object is used to specify input parameters, it can be changed after starting the timer
 output = {'foo':"Doin' my job again."}

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,8 @@ Usage
     # ...unless it gets stopped
     timer.stop()
 
+    # and potentially waited for (in case an iteration was in progress)
+    timer.join()
 
     # If a mutable object is used to specify input parameters, it can be changed after starting the timer
     output = {'foo':"Doin' my job again."}

--- a/multitimer.py
+++ b/multitimer.py
@@ -109,6 +109,7 @@ class MultiTimer(object):
     Start this timer by calling .start().  Once started, calling .stop() will terminate the
     timer's loop and not produce any further calls to function(). Note that if function() is
     currently in the middle of running, it will finish the current iteration and not be interrupted.
+    By calling .join(), one can wait for the timer to finish its task (if any) before proceeding further.
 
     _ontimeout_ and _params_ are deprecated in 0.2, and replaced by _function_, _args_
     and _kwargs_, to match the threading.Timer API.
@@ -159,6 +160,12 @@ class MultiTimer(object):
     def stop(self):
         self._timer.stop()
 
+    def join(self):
+        """Wait for the current task to finish, if any."""
+        assert not self._timer or self._timer.stopevent.is_set(), "timer must be stopped before being joined"
+        if self._timer:
+            self._timer.join()
+        
     @property
     def interval(self):
         return self._interval

--- a/test_multitimer.py
+++ b/test_multitimer.py
@@ -27,6 +27,29 @@ pprint(offsets)
 
 
 #%%
+result = []
+def increment_func():
+    sleep(2)
+    result.append(42)
+    
+rpt = multitimer.MultiTimer(interval=1, function=increment_func, runonstart=True)
+rpt.join()  # Does nothing
+rpt.start()
+
+try:
+    rpt.join() 
+except AssertionError:
+    pass
+else:
+    raise RuntimeError("should have failed")
+    
+rpt.stop()
+assert len(result) == 0
+rpt.join() 
+assert len(result) == 1
+
+
+#%%
 def output_func(output):
     print('{:.3f}: {}'.format(perf_counter()-rpt.starttime, output))
 


### PR DESCRIPTION
This allows callers to synchronize with the *real* termination of the secondary thread.